### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,7 @@ edition = "2018"
 maintenance = { status = "passively-maintained" }
 travis-ci = { repository = "katyo/fetch_unroll" }
 
-[dependencies.ureq]
-version = "0.11"
-
-[dependencies.libflate]
-version = "0.1"
-
-[dependencies.tar]
-version = "0.4"
+[dependencies]
+ureq = "1.5"
+libflate = "1.0"
+tar = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,10 +92,13 @@ impl From<&HttpError> for Error {
             DnsFailed(dns) => format!("Unresolved domain name: {}", dns),
             ConnectionFailed(error) => format!("Reset connection: {}", error),
             TooManyRedirects => "Infinite redirect loop".to_string(),
-            BadStatusRead => "Unable to read status".to_string(),
             BadStatus => "Invalid status".to_string(),
             BadHeader => "Unable to read headers".to_string(),
             Io(error) => format!("Network error: {}", error),
+            BadProxy => "Bad proxy".to_string(),
+            ProxyConnect => "Proxy connection error".to_string(),
+            BadProxyCreds => "Bad proxy creds".to_string(),
+            InvalidProxyCreds => "Invalid proxy creds".to_string(),
         })
     }
 }


### PR DESCRIPTION
Let's use the latest ureq to try to avoid old rust-tls versions.